### PR TITLE
Fix PostgreSQL backend for spectrum

### DIFF
--- a/src/pqxxbackend.cpp
+++ b/src/pqxxbackend.cpp
@@ -355,7 +355,7 @@ bool PQXXBackend::removeUser(long id) {
 		pqxx::nontransaction txn(*m_conn);
 		txn.exec("DELETE FROM " + m_prefix + "users WHERE id=" + pqxx::to_string(id));
 		txn.exec("DELETE FROM " + m_prefix + "buddies WHERE user_id=" + pqxx::to_string(id));
-		txn.exec("DELETE FROM " + m_prefix + "user_settings WHERE user_id=" + pqxx::to_string(id));
+		txn.exec("DELETE FROM " + m_prefix + "users_settings WHERE user_id=" + pqxx::to_string(id));
 		txn.exec("DELETE FROM " + m_prefix + "buddies_settings WHERE user_id=" + pqxx::to_string(id));
 
 		return true;


### PR DESCRIPTION
- fix SET to WHERE in statements in removeUser()
- fix user_settings to users_settings in removeUser()
- fix missing m_prefix in INSERT INTO db_version
