### PR TITLE
Sample config fixes

### DIFF
--- a/spectrum/src/sample.cfg
+++ b/spectrum/src/sample.cfg
@@ -4,7 +4,7 @@ password = secret
 server = 127.0.0.1
 port = 5222
 server_mode = 1
-backend_host=localhost
+backend_host=127.0.0.1
 pidfile=./test.pid
 # < this option doesn't work yet
 #backend_port=10001

--- a/spectrum/src/sample2.cfg
+++ b/spectrum/src/sample2.cfg
@@ -16,7 +16,7 @@ server = 127.0.0.1
 port = 5222
 
 # Interface on which Spectrum listens for backends.
-backend_host = localhost
+backend_host = 127.0.0.1
 
 # Port on which Spectrum listens for backends.
 # By default Spectrum chooses random backend port and there's
@@ -31,12 +31,16 @@ backend_host = localhost
 
 # Number of users per one legacy network backend.
 users_per_backend=10
+# For Skype - must be =1
+#users_per_backend=1
 
 # Full path to backend binary.
 backend=/usr/bin/spectrum2_libpurple_backend
 #backend=/usr/bin/spectrum2_libcommuni_backend
 # For skype:
 #backend=/usr/bin/xvfb-run -a -s "-screen 0 10x10x8" -f /tmp/x-skype-gw /usr/bin/spectrum2_skype_backend
+# For skype if instance drops privileges (`user`/`group` options) we should set writable HOME folder for D-BUS:
+#backend=/usr/bin/env HOME=/var/lib/spectrum2 xvfb-run -a -s "-screen 0 10x10x8" -f /tmp/x-skype-gw /usr/bin/spectrum2_skype_backend
 
 # Libpurple protocol-id for spectrum_libpurple_backend
 protocol=prpl-jabber

--- a/spectrum/src/sample2_gateway.cfg
+++ b/spectrum/src/sample2_gateway.cfg
@@ -16,7 +16,7 @@ server = 127.0.0.1
 port = 5347
 
 # Interface on which Spectrum listens for backends.
-backend_host = localhost
+backend_host = 127.0.0.1
 
 # Port on which Spectrum listens for backends.
 # By default Spectrum chooses random backend port and there's
@@ -25,12 +25,16 @@ backend_host = localhost
 
 # Number of users per one legacy network backend.
 users_per_backend=10
+# For Skype - must be =1
+#users_per_backend=1
 
 # Full path to backend binary.
 backend=/usr/bin/spectrum2_libpurple_backend
 #backend=/usr/bin/spectrum2_libcommuni_backend
 # For skype:
 #backend=/usr/bin/xvfb-run -a -s "-screen 0 10x10x8" -f /tmp/x-skype-gw /usr/bin/spectrum2_skype_backend
+# For skype if instance drops privileges (`user`/`group` options) we should set writable HOME folder for D-BUS:
+#backend=/usr/bin/env HOME=/var/lib/spectrum2 xvfb-run -a -s "-screen 0 10x10x8" -f /tmp/x-skype-gw /usr/bin/spectrum2_skype_backend
 
 # Libpurple protocol-id for spectrum_libpurple_backend
 protocol=prpl-jabber


### PR DESCRIPTION
Correctly bind to local network (`localhost` doesn't bound the interface).

Correct non-root skype backend launch needs writable ~/ folder for D-BUS daemon.
