### PR TITLE
protobuf wants the syntax version defined

### DIFF
--- a/include/transport/protocol.proto
+++ b/include/transport/protocol.proto
@@ -1,5 +1,8 @@
 package pbnetwork;
 
+// define protobuf syntax version
+syntax = "proto2";
+
 enum ConnectionError {
 	CONNECTION_ERROR_NETWORK_ERROR = 0;
 	CONNECTION_ERROR_INVALID_USERNAME = 1;


### PR DESCRIPTION
According to:

[ 31%] Running Python protocol buffer compiler on protocol.proto
[libprotobuf WARNING /var/tmp/portage/dev-libs/protobuf-9999/work/protobuf-9999/src/google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: protocol.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
