### PR TITLE
Accept updated purple-hangouts primary prompt

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1606,7 +1606,8 @@ void * requestInput(const char *title, const char *primary,const char *secondary
 			((PurpleRequestInputCb) ok_cb)(user_data, "Authorization denied.");
 			return NULL;
 		}
-		else if (boost::starts_with(primaryString, "https://accounts.google.com/o/oauth2/auth")) {
+		else if (boost::starts_with(primaryString, "https://accounts.google.com/o/oauth2/auth") ||
+                                boost::starts_with(primaryString, "https://www.youtube.com/watch?v=hlDhp-eNLMU")) {
 			LOG4CXX_INFO(logger, "prpl-hangouts oauth request");
 			np->handleMessage(np->m_accounts[account], np->adminLegacyName, std::string("Please visit the following link and authorize this application: ") + primaryString, "");
 			np->handleMessage(np->m_accounts[account], np->adminLegacyName, std::string("Reply with code provided by Google: "));


### PR DESCRIPTION
The author of `purple-hangouts` has [changed the prompt](https://bitbucket.org/EionRobb/purple-hangouts/commits/cae4ef68df6977042e36edbc39b60215ae70b199) for the OAuth code. This patch allows accepting either the old or new prompt.

With this change I was able to authenticate with Hangouts using the latest `purple-hangouts` master.