### PR TITLE
Define 'foreach' in backends/libcommuni/session.cpp

### DIFF
--- a/backends/libcommuni/session.cpp
+++ b/backends/libcommuni/session.cpp
@@ -31,6 +31,7 @@
 
 #define FROM_UTF8(WHAT) QString::fromUtf8((WHAT).c_str(), (WHAT).size())
 #define TO_UTF8(WHAT) std::string((WHAT).toUtf8().data(), (WHAT).toUtf8().size())
+#define foreach BOOST_FOREACH
 
 #include "transport/Logging.h"
 


### PR DESCRIPTION
Fixes compilation issue

```
[ 64%] Building CXX object backends/libcommuni/CMakeFiles/spectrum2_libcommuni_backend.dir/session.cpp.o
cd /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni && /usr/bin/x86_64-pc-linux-gnu-g++ -DBOOST_FILESYSTEM_VERSION=3 -DDEBUG -DIRC_SHARED -DPURPLE_RUNTIME=0 -DQT_CORE_LIB -DQT_NETWORK_LIB -DQT_NO_KEYWORDS -DSPECTRUM_VERSION=\"2.0.5-git-b15fcedf\" -DSUPPORT_LEGACY_CAPS -DWITH_LIBEVENT -DWITH_LOG4CXX -DWITH_PQXX -DWITH_PROTOBUF -isystem /usr/include/qt4 -isystem /usr/include/qt4/QtCore -I/usr/include/libpurple -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -isystem /usr/include/qt4/QtNetwork -I/usr/include/qt4/Communi/IrcCore -I/usr/include/qt4/Communi/IrcUtil -I/usr/include/qt4/Communi/IrcModel -I/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include -isystem /usr/share/qt4/mkspecs/default   -DBOOST_SIGNALS_NO_DEPRECATION_WARNING -O2 -pipe   -O0 -ggdb -o CMakeFiles/spectrum2_libcommuni_backend.dir/session.cpp.o -c /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp: In member function ‘void MyIrcSession::on_socketError(QAbstractSocket::SocketError)’:
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:208:22: error: expected primary-expression before ‘*’ token
   foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		      ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:208:23: error: ‘buffer’ was not declared in this scope
   foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		       ^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:208:23: note: suggested alternative:
In file included from /usr/include/boost/asio/detail/reactive_socket_service.hpp:22:0,
		 from /usr/include/boost/asio/socket_acceptor_service.hpp:29,
		 from /usr/include/boost/asio/basic_socket_acceptor.hpp:25,
		 from /usr/include/boost/asio/ip/tcp.hpp:19,
		 from /usr/include/Swiften/Network/HostAddressPort.h:9,
		 from /usr/include/Swiften/Elements/S5BProxyRequest.h:22,
		 from /usr/include/Swiften/Parser/PayloadParsers/S5BProxyRequestParser.h:18,
		 from /usr/include/Swiften/Swiften.h:112,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.h:30,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:21:
/usr/include/boost/asio/buffer.hpp:1231:24: note:   ‘boost::asio::buffer’
 inline const_buffers_1 buffer(
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:208:55: error: ‘foreach’ was not declared in this scope
 ch (IrcBuffer *buffer, m_bufferModel->buffers()) {
						^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:208:55: note: suggested alternative:
In file included from /usr/include/boost/foreach.hpp:86:0,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include/transport/Config.h:24,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/ircnetworkplugin.h:27,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:30:
/usr/include/boost/foreach_fwd.hpp:26:11: note:   ‘boost::foreach’
 namespace foreach
	   ^~~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp: In member function ‘void MyIrcSession::on_namesMessageReceived(IrcMessage*)’:
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:348:19: error: expected primary-expression before ‘*’ token
  foreach (IrcUser *user, userModel->users()) {
		   ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:348:20: error: ‘user’ was not declared in this scope
  foreach (IrcUser *user, userModel->users()) {
		    ^~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:348:44: error: ‘foreach’ was not declared in this scope
  foreach (IrcUser *user, userModel->users()) {
					    ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:348:44: note: suggested alternative:
In file included from /usr/include/boost/foreach.hpp:86:0,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include/transport/Config.h:24,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/ircnetworkplugin.h:27,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:30:
/usr/include/boost/foreach_fwd.hpp:26:11: note:   ‘boost::foreach’
 namespace foreach
	   ^~~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp: In member function ‘void MyIrcSession::sendMessageToFrontend(const string&, const string&, const string&)’:
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:387:23: error: expected primary-expression before ‘*’ token
    foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		       ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:387:24: error: ‘buffer’ was not declared in this scope
    foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:387:24: note: suggested alternative:
In file included from /usr/include/boost/asio/detail/reactive_socket_service.hpp:22:0,
		 from /usr/include/boost/asio/socket_acceptor_service.hpp:29,
		 from /usr/include/boost/asio/basic_socket_acceptor.hpp:25,
		 from /usr/include/boost/asio/ip/tcp.hpp:19,
		 from /usr/include/Swiften/Network/HostAddressPort.h:9,
		 from /usr/include/Swiften/Elements/S5BProxyRequest.h:22,
		 from /usr/include/Swiften/Parser/PayloadParsers/S5BProxyRequestParser.h:18,
		 from /usr/include/Swiften/Swiften.h:112,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.h:30,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:21:
/usr/include/boost/asio/buffer.hpp:1231:24: note:   ‘boost::asio::buffer’
 inline const_buffers_1 buffer(
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:387:56: error: ‘foreach’ was not declared in this scope
 ch (IrcBuffer *buffer, m_bufferModel->buffers()) {
						^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:387:56: note: suggested alternative:
In file included from /usr/include/boost/foreach.hpp:86:0,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include/transport/Config.h:24,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/ircnetworkplugin.h:27,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:30:
/usr/include/boost/foreach_fwd.hpp:26:11: note:   ‘boost::foreach’
 namespace foreach
	   ^~~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp: In member function ‘void MyIrcSession::on_numericMessageReceived(IrcMessage*)’:
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:465:23: error: expected primary-expression before ‘*’ token
    foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		       ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:465:24: error: ‘buffer’ was not declared in this scope
    foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:465:24: note: suggested alternative:
In file included from /usr/include/boost/asio/detail/reactive_socket_service.hpp:22:0,
		 from /usr/include/boost/asio/socket_acceptor_service.hpp:29,
		 from /usr/include/boost/asio/basic_socket_acceptor.hpp:25,
		 from /usr/include/boost/asio/ip/tcp.hpp:19,
		 from /usr/include/Swiften/Network/HostAddressPort.h:9,
		 from /usr/include/Swiften/Elements/S5BProxyRequest.h:22,
		 from /usr/include/Swiften/Parser/PayloadParsers/S5BProxyRequestParser.h:18,
		 from /usr/include/Swiften/Swiften.h:112,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.h:30,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:21:
/usr/include/boost/asio/buffer.hpp:1231:24: note:   ‘boost::asio::buffer’
 inline const_buffers_1 buffer(
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:465:56: error: ‘foreach’ was not declared in this scope
 ch (IrcBuffer *buffer, m_bufferModel->buffers()) {
						^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:465:56: note: suggested alternative:
In file included from /usr/include/boost/foreach.hpp:86:0,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include/transport/Config.h:24,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/ircnetworkplugin.h:27,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:30:
/usr/include/boost/foreach_fwd.hpp:26:11: note:   ‘boost::foreach’
 namespace foreach
	   ^~~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:490:23: error: expected primary-expression before ‘*’ token
    foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		       ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp: In member function ‘void MyIrcSession::awayTimeout()’:
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:523:21: error: expected primary-expression before ‘*’ token
  foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		     ^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:523:22: error: ‘buffer’ was not declared in this scope
  foreach (IrcBuffer *buffer, m_bufferModel->buffers()) {
		      ^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:523:22: note: suggested alternative:
In file included from /usr/include/boost/asio/detail/reactive_socket_service.hpp:22:0,
		 from /usr/include/boost/asio/socket_acceptor_service.hpp:29,
		 from /usr/include/boost/asio/basic_socket_acceptor.hpp:25,
		 from /usr/include/boost/asio/ip/tcp.hpp:19,
		 from /usr/include/Swiften/Network/HostAddressPort.h:9,
		 from /usr/include/Swiften/Elements/S5BProxyRequest.h:22,
		 from /usr/include/Swiften/Parser/PayloadParsers/S5BProxyRequestParser.h:18,
		 from /usr/include/Swiften/Swiften.h:112,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.h:30,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:21:
/usr/include/boost/asio/buffer.hpp:1231:24: note:   ‘boost::asio::buffer’
 inline const_buffers_1 buffer(
			^~~~~~
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:523:54: error: ‘foreach’ was not declared in this scope
 ch (IrcBuffer *buffer, m_bufferModel->buffers()) {
						^
/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:523:54: note: suggested alternative:
In file included from /usr/include/boost/foreach.hpp:86:0,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/include/transport/Config.h:24,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/ircnetworkplugin.h:27,
		 from /var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999/backends/libcommuni/session.cpp:30:
/usr/include/boost/foreach_fwd.hpp:26:11: note:   ‘boost::foreach’
 namespace foreach
	   ^~~~~~~
make[2]: *** [backends/libcommuni/CMakeFiles/spectrum2_libcommuni_backend.dir/build.make:126: backends/libcommuni/CMakeFiles/spectrum2_libcommuni_backend.dir/session.cpp.o] Error 1
make[2]: Leaving directory '/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999'
make[1]: *** [CMakeFiles/Makefile2:646: backends/libcommuni/CMakeFiles/spectrum2_libcommuni_backend.dir/all] Error 2
make[1]: Leaving directory '/var/tmp/portage/net-im/spectrum-9999/work/spectrum-9999'
make: *** [Makefile:152: all] Error 2
```