### PR TITLE
Wrap incoming images in x:oob tag

### DIFF
--- a/include/transport/NetworkPluginServer.h
+++ b/include/transport/NetworkPluginServer.h
@@ -42,6 +42,7 @@
 #include "Swiften/SwiftenCompat.h"
 #include <Swiften/Version.h>
 #include <Swiften/FileTransfer/FileTransfer.h>
+#include "transport/protocol.pb.h"
 #define HAVE_SWIFTEN_3  (SWIFTEN_VERSION >= 0x030000)
 
 #define NETWORK_PLUGIN_API_VERSION (1)
@@ -177,6 +178,8 @@ class NetworkPluginServer : Swift::XMPPParserClient {
 		void handleElement(SWIFTEN_SHRPTR_NAMESPACE::shared_ptr<Swift::Element> element);
 #endif
 		void handleStreamEnd() {}
+
+		void wrapIncomingImage(Swift::Message* msg, const pbnetwork::ConversationMessage& payload);
 
 		UserManager *m_userManager;
 		VCardResponder *m_vcardResponder;

--- a/libtransport/NetworkPluginServer.cpp
+++ b/libtransport/NetworkPluginServer.cpp
@@ -1794,7 +1794,7 @@ void NetworkPluginServer::handleBuddyRemoved(Buddy *b) {
 }
 
 void NetworkPluginServer::wrapIncomingImage(Swift::Message* msg, const pbnetwork::ConversationMessage& payload) {
-    static boost::regex image_expr{"<img src=[\"']([^\"']+)[\"'].*>"};
+    static boost::regex image_expr("<img src=[\"']([^\"']+)[\"'].*>");
 
     if (payload.xhtml().find("<img") != std::string::npos) {
         boost::smatch match;


### PR DESCRIPTION
This was suggested in #233 .
This fixes display of incoming images in clients which don't support XHTML (like Conversations), and (as far as I can see) works at least for Telegram and Hangouts.