### PR TITLE
hack to handle incoming files which come as an absolute path

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -27,6 +27,8 @@
 #include <boost/locale.hpp>
 #include <boost/locale/conversion.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/regex.hpp>
+#include <boost/filesystem.hpp>
 
 #ifdef WITH_LIBEVENT
 #include <event.h>
@@ -1222,6 +1224,61 @@ static char *calculate_data_hash(guchar *data, size_t len,
 	return g_strdup(digest);
 }
 
+static std::string check_incoming_document(const char *msg) {
+	/*
+		Sometimes, when a user sends a file, we receive a link with an absolute
+		path to the saved file in the backend's directory. This is a hack
+		which matches those links, moves the file to the web directory
+		and sends a proper link to the user.
+
+		This has to be fixed in the backend.
+	*/
+	if (strstr(msg, "[document") == NULL) {
+		return "";
+	}
+
+	static boost::regex document_expr("\[document <a href=[\"']file:///([^\"']+/download_([0-9]+)[^\"']+)[\"']>(.*)</a>[ ]*(.*)]");
+	boost::smatch match;
+	std::string plain;
+
+	if (!boost::regex_search(std::string(msg), match, document_expr)) {
+		return "";
+	}
+
+	std::string target_dir = CONFIG_STRING(config, "service.web_directory");
+	std::string local_file = match[1];
+	std::string hash = match[2];
+	std::string basename = match[3];
+	std::string file_type = match[4];
+
+	if (!target_dir.empty()) {
+		target_dir += "/" + hash;	// todo: escape
+		std::string target_file = target_dir + "/" + basename;
+		std::string link = CONFIG_STRING(config, "service.web_url") + "/" + hash + "/" + basename;
+
+		boost::filesystem::create_directories(
+			boost::filesystem::path(target_dir)
+		);
+
+		boost::filesystem::rename(
+			boost::filesystem::path(local_file),
+			boost::filesystem::path(target_file)
+		);
+
+		plain
+			= std::string("file ")
+			+ "\"" + basename + "\""
+			+ " of type ["
+			+ file_type
+			+ "]: "
+			+ link;
+	} else {
+		plain = "[received a file]";
+	}
+
+	return plain;
+}
+
 static void conv_write_im(PurpleConversation *conv, const char *who, const char *msg, PurpleMessageFlags flags, time_t mtime) {
 	// Don't forwards our own messages.
 	if (purple_conversation_get_type_wrapped(conv) == PURPLE_CONV_TYPE_IM && (flags & PURPLE_MESSAGE_SEND || flags & PURPLE_MESSAGE_SYSTEM)) {
@@ -1297,15 +1354,26 @@ static void conv_write_im(PurpleConversation *conv, const char *who, const char 
 		g_free(strip);
 	}
 	else {
-		// Escape HTML characters.
-		char *newline = purple_strdup_withhtml_wrapped(msg);
-		char *strip, *xhtml;
-		purple_markup_html_to_xhtml_wrapped(newline, &xhtml, &strip);
-		message_ = strip;
-		xhtml_ = xhtml;
-		g_free(newline);
-		g_free(xhtml);
-		g_free(strip);
+		std::string file_link = check_incoming_document(msg);
+
+		if (!file_link.empty()) {
+			char *strip, *xhtml;
+			purple_markup_html_to_xhtml_wrapped(file_link.c_str(), &xhtml, &strip);
+			message_ = strip;
+			xhtml_ = xhtml;
+			g_free(xhtml);
+			g_free(strip);
+		} else {
+            // Escape HTML characters.
+            char *newline = purple_strdup_withhtml_wrapped(msg);
+            char *strip, *xhtml;
+            purple_markup_html_to_xhtml_wrapped(newline, &xhtml, &strip);
+            message_ = strip;
+            xhtml_ = xhtml;
+            g_free(newline);
+            g_free(xhtml);
+            g_free(strip);
+        }
 	}
 
 	// AIM and XMPP adds <body>...</body> here...


### PR DESCRIPTION
Just to be clear: This pull request proposes a **nasty workaround**. If someone could point the root cause so that this can be properly fixed, it would be much better.

**Current behaviour:**
when receiving a file through the libpurple backend from a service which uses cloud storage (such as telegram, skypeweb etc), `conv_write_im` gets passed a message which looks like this:
```
[document <a href="file:////var/lib/spectrum2/telegram.my.domain/telegram-purple/+88888888888/downloads/download_5913692237379666901.bin">file_name.txt</a> text/plain 38 bytes]
```
And so, the message is sent to the user, resulting in them seeing a raw filesystem path on the server (ugh!)

**Workaround:**
This seems to be happening somewhere in libpurple. Since I'm (so far) unable to locate it, I'm proposing this workaround, which matches those messages, moves the respectful file to the web storage (if enabled), and modifies the message to include a proper link.