### PR TITLE
A bunch of packaging fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:23
 
 EXPOSE 5222
 VOLUME ["/etc/spectrum2/transports", "/var/lib/spectrum2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG commit=unknown
 RUN echo $commit
 
 # Spectrum 2
-RUN dnf install protobuf protobuf swiften gcc gcc-c++ make libpqxx-devel libpurple-devel protobuf-devel swiften-devel rpm-build avahi-devel boost-devel cmake cppunit-devel expat-devel libcommuni-devel libidn-devel libsqlite3x-devel log4cxx-devel gettext libgcrypt-devel libwebp-devel libpurple-devel zlib-devel json-glib-devel python-pip zlib-devel libjpeg-devel python-devel  mysql-devel popt-devel git libevent-devel qt-devel dbus-glib-devel libcurl-devel wget mercurial libtool libgnome-keyring-devel nss-devel -y && \
+RUN dnf install protobuf protobuf swiften gcc gcc-c++ make libpqxx-devel libpurple-devel protobuf-devel swiften-devel rpm-build avahi-devel boost-devel cmake cppunit-devel expat-devel libcommuni-devel libidn-devel libsqlite3x-devel log4cxx-devel gettext libgcrypt-devel libwebp-devel libpurple-devel zlib-devel json-glib-devel python-pip zlib-devel libjpeg-devel python-devel mysql-devel popt-devel git libev-libevent-devel qt-devel dbus-glib-devel libcurl-devel wget mercurial libtool libgnome-keyring-devel nss-devel -y && \
 	echo "---> Installing Spectrum 2" && \
 		git clone git://github.com/hanzz/spectrum2.git && \
 		cd spectrum2 && \
@@ -84,7 +84,7 @@ RUN dnf install protobuf protobuf swiften gcc gcc-c++ make libpqxx-devel libpurp
 		rm -rf /usr/lib64/libQtHelp* && \
 		rm -rf /usr/lib64/libQtDesigner* && \
 		rm -rf /usr/lib64/libQt3* && \
-		dnf remove protobuf-devel swiften-devel gcc gcc-c++ libpqxx-devel libevent-devel qt-devel dbus-glib-devel libpurple-devel make rpm-build avahi-devel boost-devel cmake cppunit-devel expat-devel libcommuni-devel libidn-devel libsqlite3x-devel libgcrypt-devel libwebp-devel libpurple-devel zlib-devel json-glib-devel zlib-devel libjpeg-devel python-devel  log4cxx-devel mysql-devel popt-devel libcurl-devel spectrum2-debuginfo yum perl wget -y && \
+		dnf remove protobuf-devel swiften-devel gcc gcc-c++ libpqxx-devel libev-libevent-devel qt-devel dbus-glib-devel libpurple-devel rpm-build avahi-devel boost-devel cmake cppunit-devel expat-devel libcommuni-devel libidn-devel libsqlite3x-devel libgcrypt-devel libwebp-devel libpurple-devel zlib-devel json-glib-devel zlib-devel libjpeg-devel python-devel log4cxx-devel mysql-devel popt-devel libcurl-devel spectrum2-debuginfo wget -y && \
 		dnf clean all -y && \
 		rm -rf /var/lib/rpm/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:23
+FROM fedora:latest
 
 EXPOSE 5222
 VOLUME ["/etc/spectrum2/transports", "/var/lib/spectrum2"]

--- a/packaging/debian/debian/rules
+++ b/packaging/debian/debian/rules
@@ -8,7 +8,7 @@ DEB_UPSTREAM_VERSION = $(shell dpkg-parsechangelog -ldebian/changelog \
 
 build:
 	dh_testdir
-	cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr -DSPECTRUM_VERSION=${DEB_UPSTREAM_VERSION} .
+	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr -DSPECTRUM_VERSION=${DEB_UPSTREAM_VERSION} .
 	export VERBOSE=1
 	VERBOSE=1 make VERBOSE=1
 

--- a/packaging/fedora/spectrum2.spec
+++ b/packaging/fedora/spectrum2.spec
@@ -27,6 +27,10 @@ BuildRequires: avahi-devel
 BuildRequires: log4cxx-devel
 BuildRequires: swiften-devel
 BuildRequires: libcommuni-devel
+BuildRequires: libcurl-devel
+BuildRequires: libev-libevent-devel
+BuildRequires: libpqxx-devel
+BuildRequires: libpurple-devel
 Requires:      libtransport%{?_isa} = %{version}-%{release}
 
 %description

--- a/packaging/fedora/spectrum2.spec
+++ b/packaging/fedora/spectrum2.spec
@@ -36,7 +36,7 @@ Spectrum 2 is an XMPP transport/gateway and also simple XMPP server.
 %setup -q -n spectrum2
 
 %build
-%cmake . -DCMAKE_BUILD_TYPE=Debug
+%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
 make VERBOSE=1 %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
This pull request contains the following changes:
* Build Debian and RPM packages with optimisations enabled (fixes #270)
* Add missing build dependencies to the RPM .spec file
* Base the Docker image on the latest stable Fedora release instead of Fedora 23, which has been unsupported for over a year