### PR TITLE
systemd: wait for network-online.target and add WantedBy=multi-user.target

### DIFF
--- a/packaging/debian/debian/spectrum2.service
+++ b/packaging/debian/debian/spectrum2.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=spectrum2
-After=network.target
+Wants=network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=forking
@@ -10,4 +11,4 @@ ExecStop=/usr/bin/spectrum2_manager stop
 ExecReload=/usr/bin/spectrum2_manager restart
 
 [Install]
-Alias=spectrum2
+WantedBy=multi-user.target


### PR DESCRIPTION
Thanks to that, "systemctl enable spectrum2" does what expected, that is
makes Spectrum2 start on boot. Also, network.target doesn't tell anything
meaningful - it's just that the network stack is available.
Adding network-online.target makes sure that the network interfaces are up
before starting Spectrum2.