### PR TITLE
Store Steam Mobile access token in storage backend

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -190,6 +190,7 @@ static std::string getAlias(PurpleBuddy *m_buddy) {
 
 static boost::mutex dblock;
 static std::string OAUTH_TOKEN = "hangouts_oauth_token";
+static std::string STEAM_ACCESS_TOKEN = "steammobile_access_token";
 
 static bool getUserOAuthToken(const std::string user, std::string &token)
 {
@@ -214,6 +215,32 @@ static bool storeUserOAuthToken(const std::string user, const std::string OAuthT
 		return false;
 	}
 	storagebackend->updateUserSetting((long)info.id, OAUTH_TOKEN, OAuthToken);
+	return true;
+}
+
+static bool getUserSteamAccessToken(const std::string user, std::string &token)
+{
+	boost::mutex::scoped_lock lock(dblock);
+	UserInfo info;
+	if(storagebackend->getUser(user, info) == false) {
+		LOG4CXX_ERROR(logger, "Didn't find entry for " << user << " in the database!");
+		return false;
+	}
+	token = "";
+	int type = TYPE_STRING;
+	storagebackend->getUserSetting((long)info.id, STEAM_ACCESS_TOKEN, type, token);
+	return true;
+}
+
+static bool storeUserSteamAccessToken(const std::string user, const std::string token)
+{
+	boost::mutex::scoped_lock lock(dblock);
+	UserInfo info;
+	if(storagebackend->getUser(user, info) == false) {
+		LOG4CXX_ERROR(logger, "Didn't find entry for " << user << " in the database!");
+		return false;
+	}
+	storagebackend->updateUserSetting((long)info.id, STEAM_ACCESS_TOKEN, token);
 	return true;
 }
 
@@ -414,6 +441,12 @@ class SpectrumNetworkPlugin : public NetworkPlugin {
 				std::string token;
 				if (getUserOAuthToken(user, token)) {
 					purple_account_set_password_wrapped(account, token.c_str());
+				}
+			}
+			else if (protocol == "prpl-steam-mobile") {
+				std::string token;
+				if (getUserSteamAccessToken(user, token)) {
+					purple_account_set_string_wrapped(account, "access_token", token.c_str());
 				}
 			}
 
@@ -2086,6 +2119,9 @@ static void signed_on(PurpleConnection *gc, gpointer unused) {
 	if (CONFIG_STRING(config, "service.protocol") == "prpl-hangouts") {
 		storeUserOAuthToken(np->m_accounts[account], purple_account_get_password_wrapped(account));
 	}
+	else if (CONFIG_STRING(config, "service.protocol") == "prpl-steam-mobile") {
+		storeUserSteamAccessToken(np->m_accounts[account], purple_account_get_string_wrapped(account, "access_token", NULL));
+	}
 }
 
 static void printDebug(PurpleDebugLevel level, const char *category, const char *arg_s) {
@@ -2314,11 +2350,11 @@ int main(int argc, char **argv) {
 	config = SWIFTEN_SHRPTR_NAMESPACE::shared_ptr<Config>(cfg);
 
 	Logging::initBackendLogging(config.get());
-	if (CONFIG_STRING(config, "service.protocol") == "prpl-hangouts") {
+	if (CONFIG_STRING(config, "service.protocol") == "prpl-hangouts" || CONFIG_STRING(config, "service.protocol") == "prpl-steam-mobile") {
 		storagebackend = StorageBackend::createBackend(config.get(), error);
 		if (storagebackend == NULL) {
 			LOG4CXX_ERROR(logger, "Error creating StorageBackend! " << error);
-			LOG4CXX_ERROR(logger, "Hangouts backend needs storage backend configured to work! " << error);
+			LOG4CXX_ERROR(logger, "Hangouts and Steam backends need storage backend configured to work! " << error);
 			return NetworkPlugin::StorageBackendNeeded;
 		}
 		else if (!storagebackend->connect()) {

--- a/backends/libpurple/purple_defs.h
+++ b/backends/libpurple/purple_defs.h
@@ -23,6 +23,9 @@ extern purple_account_get_protocol_id_wrapped_fnc purple_account_get_protocol_id
 typedef void  (_cdecl * purple_account_set_int_wrapped_fnc)(PurpleAccount *account, const char *name, int value);
 extern purple_account_set_int_wrapped_fnc purple_account_set_int_wrapped;
 
+typedef const char * (_cdecl * purple_account_get_string_wrapped_fnc)(PurpleAccount *account, const char *name, const char *default_value);
+extern purple_account_get_string_wrapped_fnc purple_account_get_string_wrapped;
+
 typedef void  (_cdecl * purple_account_set_string_wrapped_fnc)(PurpleAccount *account, const char *name, const char *value);
 extern purple_account_set_string_wrapped_fnc purple_account_set_string_wrapped;
 
@@ -478,6 +481,7 @@ extern wpurple_g_io_channel_win32_new_socket_wrapped_fnc wpurple_g_io_channel_wi
 #define purple_account_set_bool_wrapped purple_account_set_bool
 #define purple_account_get_protocol_id_wrapped purple_account_get_protocol_id
 #define purple_account_set_int_wrapped purple_account_set_int
+#define purple_account_get_string_wrapped purple_account_get_string
 #define purple_account_set_string_wrapped purple_account_set_string
 #define purple_account_get_username_wrapped purple_account_get_username
 #define purple_account_set_username_wrapped purple_account_set_username


### PR DESCRIPTION
I patched the libpurple backend to store and retrieve the Steam Mobile access token to and from the database. This is a partial fix for #264.

I'm not 100% sure whether this is correctly implemented, but it works for me this way. Maybe someone with more C++ knowledge can check and optimize it.