### PR TITLE
libtransport: add missing semicolon

### DIFF
--- a/libtransport/NetworkPluginServer.cpp
+++ b/libtransport/NetworkPluginServer.cpp
@@ -1815,7 +1815,7 @@ void NetworkPluginServer::wrapIncomingImage(Swift::Message* msg, const pbnetwork
             msg->addPayload(oob_payload);
             msg->setBody(image_url);
         } else {
-            LOG4CXX_WARN(logger, "xhtml seems to contain an image, but doesn't match: " + payload.xhtml())
+            LOG4CXX_WARN(logger, "xhtml seems to contain an image, but doesn't match: " + payload.xhtml());
         }
     }
 }


### PR DESCRIPTION
There appears to be a missing semicolon on line 1818 of `NetworkPluginServer.cpp`. This causes compilation to fail with the following error message when using the latest git version of log4cxx.

```
spectrum2/src/spectrum2-2.0.7/libtransport/NetworkPluginServer.cpp: In member function ‘void Transport::NetworkPluginServer::wrapIncomingImage(Swift::Message*, const pbnetwork::ConversationMessage&)’:
spectrum2/src/spectrum2-2.0.7/libtransport/NetworkPluginServer.cpp:1819:9: error: expected ‘;’ before ‘}’ token
```