### PR TITLE
Image handling improvements

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1419,7 +1419,7 @@ static void conv_write_im(PurpleConversation *conv, const char *who, const char 
 		if(flags & PURPLE_MESSAGE_SEND)
 			isCarbon = true;
 
-		//Ignore system messages as those are normally not true messags in the XMPP sense
+		//Ignore system messages as those are normally not true messages in the XMPP sense
 		if (flags & PURPLE_MESSAGE_SYSTEM) {
 			LOG4CXX_INFO(logger, "conv_write_im(): ignoring a system message");
 			return;
@@ -1428,7 +1428,7 @@ static void conv_write_im(PurpleConversation *conv, const char *who, const char 
 	PurpleAccount *account = purple_conversation_get_account_wrapped(conv);
 
 	std::string message_; //plain text
-	std::string xhtml_;   //enhanced xhtml version, if available
+	std::string xhtml_;   //enhanced xhtml, if available
 
 	//LOG4CXX_INFO(logger, "conv_write_im(): msg='" << msg << "'");
 

--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1473,7 +1473,7 @@ static void conv_write_im(PurpleConversation *conv, const char *who, const char 
 			n = w.substr((int) pos + 1, w.length() - (int) pos);
 			w.erase((int) pos, w.length() - (int) pos);
 		}
-		LOG4CXX_INFO(logger_libpurple, "Received message body='" << message_ << "' xhtml='" << xhtml_ << "' name='" << w << "'");
+		LOG4CXX_INFO(logger, "Received message body='" << message_ << "' xhtml='" << xhtml_ << "' name='" << w << "'");
 		np->handleMessage(np->m_accounts[account], w, message_, n, xhtml_, timestamp, false, false, isCarbon);
 	}
 	else {

--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1340,7 +1340,7 @@ static bool conv_msg_to_image(const char* msg, std::string* xhtml_, std::string*
 		std::string name;
 		guchar * data = (guchar *) purple_imgstore_get_data_wrapped(image);
 		size_t len = purple_imgstore_get_size_wrapped(image);
-		if (len < 1000000 && data) {
+		if (len < CONFIG_INT(config, "service.web_maximgsize") && data) {
 			ext = purple_imgstore_get_extension(image);
 			char *hash = calculate_data_hash(data, len, "sha1");
 			if (!hash) {

--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1402,9 +1402,6 @@ static void conv_write_im(PurpleConversation *conv, const char *who, const char 
 	}
 	else {
 		conv_msg_to_plain(msg, &xhtml_, &message_);
-		//Don't silently discard empty messages - at least make the user aware
-		if (message_.empty() && xhtml_.empty())
-			message_ = " "; //a space
 	}
 
 	// AIM and XMPP adds <body>...</body> here...

--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1370,7 +1370,7 @@ static bool conv_msg_to_image(const char* msg, std::string* xhtml_, std::string*
 			}
 		}
 		else {
-			LOG4CXX_WARN(logger, "Image bigger than 1MB.");
+			LOG4CXX_WARN(logger, "Image bigger than the allowed size (web_maximgsize).");
 			purple_imgstore_unref_wrapped(image);
 			return false;
 		}

--- a/libtransport/Config.cpp
+++ b/libtransport/Config.cpp
@@ -107,6 +107,7 @@ bool Config::load(std::istream &ifs, boost::program_options::options_description
 		("service.frontend", value<std::string>()->default_value("xmpp"), "")
 		("service.web_directory", value<std::string>()->default_value(""), "Full path to directory used to save files to which the links are sent to users.")
 		("service.web_url", value<std::string>()->default_value(""), "URL on which files in web_directory are accessible.")
+		("service.web_maximgsize", value<int>()->default_value(1000000), "Maximum image size in bytes allowed to be downloaded and stored locally.")
 		("vhosts.vhost", value<std::vector<std::string> >()->multitoken(), "")
 		("identity.name", value<std::string>()->default_value("Spectrum 2 Transport"), "Name showed in service discovery.")
 		("identity.category", value<std::string>()->default_value("gateway"), "Disco#info identity category. 'gateway' by default.")


### PR DESCRIPTION
1. If we cannot treat image as an image (web_directory disabled, image too large), treat it as a standard message at least (strip non-XHTML and forward what remains).
2. If there's nothing left after stripping out non-XHTML tags, send "[The user sent you an image]" (it's confusing if messages silently not arrive at all)
3. Added a configuration option web_maximgsize to set max image filesize (had been hardcoded to 1Mb)
4. If we already have that image in web_directory by hash, do not rewrite its contents (saves a bit of time I guess) but do update mtime
5. Fix: better quote handling when replacing ``<img id= />`` tags.
6. Fix: plaintext generated manually during the ``<img id= />`` tag replacement must still be purple_html_to_xhtmled because it can contain unrelated html snippets. (Or uncaught ``<img id= />``s as it were)

