### PR TITLE
Friend request handling improvements

### DIFF
--- a/include/transport/Logging.h
+++ b/include/transport/Logging.h
@@ -46,6 +46,7 @@ using namespace log4cxx;
 #define LOG4CXX_ERROR(LOGGER, DATA) std::cerr << "E: <" << LOGGER << "> " << DATA << "\n";
 #define LOG4CXX_WARN(LOGGER, DATA) std::cout << "W: <" << LOGGER << "> " << DATA << "\n";
 #define LOG4CXX_INFO(LOGGER, DATA) std::cout << "I: <" << LOGGER << "> " << DATA << "\n";
+#define LOG4CXX_TRACE(LOGGER, DATA)
 #endif
 
 namespace Transport {

--- a/include/transport/NetworkPlugin.h
+++ b/include/transport/NetworkPlugin.h
@@ -75,7 +75,18 @@ class NetworkPlugin {
 
 		void sendRawXML(std::string &xml);
 
-		/// Call this function when legacy network buddy changed.
+		/*
+		Spectrum backends follow Pidgin model where
+		- Buddies can only be mutual
+		- Adding a buddy sends a friend request and the buddy is not added until it's accepted.
+		- The only way to unfriend is to delete a buddy.
+		*/
+
+		/// Call this function to:
+		/// 1. Change legacy network buddy params
+		/// 2. Add buddy on the legacy network with the given params
+		///    a. Accepting their friend request if present
+		///    b. Sending a friend request from ourselves.
 		/// \param user XMPP JID of user for which this event occurs. You can get it from NetworkPlugin::handleLoginRequest(). (eg. "user%gmail.com@xmpp.domain.tld")
 		/// \param buddyName Name of legacy network buddy. (eg. "user2@gmail.com")
 		/// \param alias Alias of legacy network buddy. If empty, then it's not changed on XMPP side.
@@ -89,7 +100,9 @@ class NetworkPlugin {
 			bool blocked = false
 		);
 
-		/// Call this method when buddy is removed from legacy network contact list.
+		/// Call this method to:
+		/// 1. Removed the buddy from the legacy network contact list.
+		/// 2. Reject a friend request from this buddy.
 		/// \param user XMPP JID of user for which this event occurs. You can get it from NetworkPlugin::handleLoginRequest(). (eg. "user%gmail.com@xmpp.domain.tld")
 		/// \param buddyName Name of legacy network buddy. (eg. "user2@gmail.com")
 		void handleBuddyRemoved(const std::string &user, const std::string &buddyName);

--- a/include/transport/RosterManager.h
+++ b/include/transport/RosterManager.h
@@ -113,6 +113,8 @@ class RosterManager {
 		void sendBuddySubscribePresence(Buddy *buddy);
 		
 		void sendBuddyUnsubscribePresence(Buddy *buddy);
+		
+		void sendBuddyPresences(Buddy *buddy, const Swift::JID &to);
 
 		void sendCurrentPresences(const Swift::JID &to);
 

--- a/libtransport/Config.cpp
+++ b/libtransport/Config.cpp
@@ -98,6 +98,7 @@ bool Config::load(std::istream &ifs, boost::program_options::options_description
 		("service.more_resources", value<bool>()->default_value(false), "Allow more resources to be connected in server mode at the same time.")
 		("service.enable_privacy_lists", value<bool>()->default_value(true), "")
 		("service.enable_xhtml", value<bool>()->default_value(true), "")
+		("service.enable_remove_buddy", value<bool>()->default_value(false), "Remove your legacy network buddies when you unsubscribe from them. If disabled, you can still remove them in Spectrum but they'll remain on the legacy network roster.")
 		("service.max_room_list_size", value<int>()->default_value(100), "")
 		("service.login_delay", value<int>()->default_value(0), "")
 		("service.jid_escaping", value<bool>()->default_value(true), "")

--- a/libtransport/RosterManager.cpp
+++ b/libtransport/RosterManager.cpp
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111-1301  USA
  */
 
+#include "transport/Config.h"
 #include "transport/RosterManager.h"
 #include "transport/RosterStorage.h"
 #include "transport/StorageBackend.h"

--- a/libtransport/RosterManager.cpp
+++ b/libtransport/RosterManager.cpp
@@ -257,12 +257,11 @@ void RosterManager::handleSubscription(Swift::Presence::ref presence) {
 				LOG4CXX_TRACE(logger, "handleSubscription(): Unsubscribe/Unsubscribed");
 				//Delete buddy and reject any friend requests
 				//If delete-protection is enabled, only delete from backend if the friend is Buddy::Ask or new.
-				if (newBuddy || (buddy->getSubscription() == Buddy::Ask) || CONFIG_BOOL(m_component->getConfig(), "service.enable_remove_buddy")) {
+				if (newBuddy || (buddy->getSubscription() == Buddy::Ask) || CONFIG_BOOL(m_component->getConfig(), "service.enable_remove_buddy"))
 					onBuddyRemoved(buddy);
-					if (!newBuddy) {
-						removeBuddy(buddy->getName());
-						buddy = NULL;
-					}
+				if (!newBuddy) {
+					removeBuddy(buddy->getName());
+					buddy = NULL;
 				}
 				break;
 		}

--- a/libtransport/RosterManager.cpp
+++ b/libtransport/RosterManager.cpp
@@ -259,16 +259,12 @@ void RosterManager::handleSubscription(Swift::Presence::ref presence) {
 					removeBuddy(buddy->getName());
 					buddy = NULL;
 					break;
-				// just send response
+				// this can be a friend request rejection so remove buddy to forward it
 				case Swift::Presence::Unsubscribed:
 					response->setType(Swift::Presence::Unsubscribe);
-					// We set both here, because this Unsubscribed can be response to
-					// subscribe presence and we don't want that unsubscribe presence
-					// to be send later again
-					if (buddy->getSubscription() != Buddy::Both) {
-						buddy->setSubscription(Buddy::Both);
-						storeBuddy(buddy);
-					}
+					onBuddyRemoved(buddy);
+					removeBuddy(buddy->getName());
+					buddy = NULL;
 					break;
 				case Swift::Presence::Subscribed:
 					if (buddy->getSubscription() != Buddy::Both) {

--- a/libtransport/RosterManager.cpp
+++ b/libtransport/RosterManager.cpp
@@ -255,10 +255,13 @@ void RosterManager::handleSubscription(Swift::Presence::ref presence) {
 			case Swift::Presence::Unsubscribed:  // Remove existing friend / Reject SUBSCRIBE / Confirm UNSUBSCRIBE
 				LOG4CXX_TRACE(logger, "handleSubscription(): Unsubscribe/Unsubscribed");
 				//Delete buddy and reject any friend requests
-				onBuddyRemoved(buddy);
-				if (!newBuddy) {
-					removeBuddy(buddy->getName());
-					buddy = NULL;
+				//If delete-protection is enabled, only delete from backend if the friend is Buddy::Ask or new.
+				if (newBuddy || (buddy->getSubscription() == Buddy::Ask) || CONFIG_BOOL(m_component->getConfig(), "service.enable_remove_buddy")) {
+					onBuddyRemoved(buddy);
+					if (!newBuddy) {
+						removeBuddy(buddy->getName());
+						buddy = NULL;
+					}
 				}
 				break;
 		}

--- a/plugin/cpp/networkplugin.cpp
+++ b/plugin/cpp/networkplugin.cpp
@@ -524,7 +524,7 @@ void NetworkPlugin::handleVCardPayload(const std::string &data) {
 void NetworkPlugin::handleBuddyChangedPayload(const std::string &data) {
 	pbnetwork::Buddy payload;
 	if (payload.ParseFromString(data) == false) {
-		// TODO: ERROR
+		LOG4CXX_ERROR(logger, "handleBuddyChangedPayload(): cannot parse: " << data);
 		return;
 	}
 	if (payload.has_blocked()) {
@@ -542,7 +542,7 @@ void NetworkPlugin::handleBuddyChangedPayload(const std::string &data) {
 void NetworkPlugin::handleBuddyRemovedPayload(const std::string &data) {
 	pbnetwork::Buddy payload;
 	if (payload.ParseFromString(data) == false) {
-		// TODO: ERROR
+		LOG4CXX_ERROR(logger, "handleBuddyRemovedPayload(): cannot parse: " << data);
 		return;
 	}
 

--- a/spectrum/src/sample2_gateway.cfg
+++ b/spectrum/src/sample2_gateway.cfg
@@ -44,6 +44,9 @@ protocol=prpl-jabber
 # So for example: prpl-jabber.hanzz.k%gmail.com@domain.tld
 #protocol=any
 
+# If enabled, your legacy network buddies will be removed when you unsubscribe from them in the XMPP.
+#enable_remove_buddy=true
+
 [identity]
 # Name of Spectrum instance in service discovery
 name=Spectrum Jabber Transport


### PR DESCRIPTION
1. Fixed Issue 324's part about rejected friend requests remaining and getting redelivered.

2. Refactored the subscription code and added some comments.

Made it so that Subscribe/Subscribed and Unsubscribe/Unsubscribed work the same for the gateway. Previously it had been halfway: e.g. Unsubscribe fully removes the buddy while Unsubscribed does nothing. If anything, I think it makes more sense to remove them on Unsubscribed, because

Subscribe = please give me your status updates
Subscribed = I allow you my status updates
Unsubscribe = please deny me your status updates
Unsubscribed = I deny you my status updates

Spectrum seems to follow Pidgin model where you can only be mutual friends or neither, so 1+2 and 3+4 should only happen in pairs, which can be triggered by either action.

3. Added an option ``enable_remove_buddy`` to protect against accidental buddy removals. Unless enabled, buddies won't be removed from the backend when you delete/unsub them on the XMPP. Disabled by default. This does not prevent from rejecting friend requests.