### PR TITLE
Support Steam Guard for Mobile Authenticator and Email

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -1843,7 +1843,7 @@ void * requestInput(const char *title, const char *primary,const char *secondary
 			np->m_inputRequests[req->mainJID] = req;
 			return NULL;
 		}
-		else if (primaryString == "Set your Steam Guard Code") {
+		else if (primaryString == "Set your Steam Guard Code" || primaryString == "Steam two-factor authentication") {
 			LOG4CXX_INFO(logger, "prpl-steam-mobile steam guard request");
 			np->handleMessage(np->m_accounts[account], np->adminLegacyName, std::string("Steam Guard code: "));
 			inputRequest *req = new inputRequest;


### PR DESCRIPTION
A simple fix for #351 supporting Steam Guard Mobile Authenticator in addition to Email.