### PR TITLE
xmpp: add missing semicolon

### DIFF
--- a/spectrum/src/frontends/xmpp/carbonresponder.cpp
+++ b/spectrum/src/frontends/xmpp/carbonresponder.cpp
@@ -30,7 +30,7 @@ void CarbonResponder::start() {
 
 //Call when DiscoInfoResponder is available
 void CarbonResponder::setDiscoInfoResponder(DiscoInfoResponder *discoInfoResponder) {
-	LOG4CXX_TRACE(logger, "Registering disco#info features")
+	LOG4CXX_TRACE(logger, "Registering disco#info features");
 	discoInfoResponder->addTransportFeature("urn:xmpp:carbons:2");
 }
 


### PR DESCRIPTION
There's a missing semicolon on line 33 of `carbonresponder.cpp` that causes build failures with newer versions of `log4cxx`. Compilation fails with this error message:
```
error: expected ‘;’ before ‘discoInfoResponder’ discoInfoResponder->addTransportFeature("urn:xmpp:carbons:2");
```