### PR TITLE
Fix dfrotz compilation with GCC >= 10

### DIFF
--- a/backends/frotz/dfrotz/dumb/dumb_init.c
+++ b/backends/frotz/dfrotz/dumb/dumb_init.c
@@ -7,7 +7,7 @@
 
 #include "dumb_frotz.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 #define INFORMATION "\
 An interpreter for all Infocom and other Z-Machine games.\n\

--- a/backends/frotz/dfrotz/dumb/dumb_input.c
+++ b/backends/frotz/dfrotz/dumb/dumb_input.c
@@ -5,7 +5,7 @@
  */
 
 #include "dumb_frotz.h"
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 static char runtime_usage[] =
   "DUMB-FROTZ runtime help:\n"

--- a/backends/frotz/dfrotz/dumb/dumb_output.c
+++ b/backends/frotz/dfrotz/dumb/dumb_output.c
@@ -7,7 +7,7 @@
 
 #include "dumb_frotz.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 static bool show_line_numbers = FALSE;
 static bool show_line_types = -1;


### PR DESCRIPTION
Since GCC enables by default -fno-common,
the compilation of dfrotz due multiple definitions will fail.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>