### PR TITLE
Allow the possiblity to bind only to localhost and do that by default.

### DIFF
--- a/spectrum_manager/src/managerconfig.cpp
+++ b/spectrum_manager/src/managerconfig.cpp
@@ -31,6 +31,7 @@ bool ManagerConfig::load(const std::string &configfile, boost::program_options::
 	opts.add_options()
 		("service.admin_username", value<std::string>()->default_value(""), "Administrator username.")
 		("service.admin_password", value<std::string>()->default_value(""), "Administrator password.")
+		("service.bind", value<std::string>()->default_value("localhost"), "IP to bind. Empty: binds all interfaces.")
 		("service.port", value<int>()->default_value(8081), "Web interface port.")
 		("service.cert", value<std::string>()->default_value(""), "Web interface certificate in PEM format when TLS should be used.")
 		("service.config_directory", value<std::string>()->default_value("/etc/spectrum2/transports/"), "Directory with spectrum2 configuration files. One .cfg file per one instance")

--- a/spectrum_manager/src/server.cpp
+++ b/spectrum_manager/src/server.cpp
@@ -74,7 +74,8 @@ Server::Server(ManagerConfig *config, const std::string &config_file) {
 	memset(&opts, 0, sizeof(opts));
 	const char *error_string;
 	opts.error_string = &error_string;
-	m_nc = mg_bind_opt(&m_mgr, std::string(":" + boost::lexical_cast<std::string>(CONFIG_INT(m_config, "service.port"))).c_str(), &_event_handler, opts);
+	std::string connection_string = CONFIG_STRING(m_config, "service.bind") + ":" + boost::lexical_cast<std::string>(CONFIG_INT(m_config, "service.port"));
+	m_nc = mg_bind_opt(&m_mgr, connection_string.c_str(), &_event_handler, opts);
 	if (!m_nc) {
 		std::cerr << "Error creating server: " << error_string << "\n";
 		exit(1);

--- a/spectrum_manager/src/spectrum_manager.cfg
+++ b/spectrum_manager/src/spectrum_manager.cfg
@@ -5,6 +5,9 @@ config_directory=/etc/spectrum2/transports/
 admin_username=admin
 admin_password=test
 
+# Bind web interface to this IP only. If empty or undefined it will listen on all interfaces.
+# defaults to localhost. Set to empty string to listen on all interfaces.
+#bind=localhost
 # Port on which the Web interface is listening on
 port=8080
 


### PR DESCRIPTION
The default spectrum2 ui onfig listens to all interfaces, even if not set up. As the systemd service will start by default the server, this can have security implications.

(This is a patch from the upcoming Debian package)