### PR TITLE
Use GNUInstallDirs to setup installation target directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif(WIN32)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+include(GNUInstallDirs)
+
 include(CPack)
 message(STATUS "Variables to override default places where to find libraries:")
 message(STATUS "|- cppunit : -DCPPUNIT_INCLUDE_DIR,  -DCPPUNIT_LIBRARY")

--- a/include/transport/CMakeLists.txt
+++ b/include/transport/CMakeLists.txt
@@ -10,4 +10,4 @@ endif()
 
 file(GLOB HEADERS *.h protocol.h)
 
-install(FILES ${HEADERS} DESTINATION include/transport COMPONENT headers)
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/transport COMPONENT headers)

--- a/libtransport/CMakeLists.txt
+++ b/libtransport/CMakeLists.txt
@@ -61,7 +61,7 @@ if(APPLE)
 	target_link_libraries(transport ${APPLE_FRAMEWORKS})
 endif()
 
-install(TARGETS transport LIBRARY DESTINATION ${LIB_INSTALL_DIR} ARCHIVE DESTINATION ${LIB_INSTALL_DIR} COMPONENT libraries)
+install(TARGETS transport LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
 #configure_file(transport.pc.in "${CMAKE_CURRENT_BINARY_DIR}/transport.pc")
 #install(FILES "${CMAKE_CURRENT_BINARY_DIR}/transport.pc" DESTINATION lib/pkgconfig)

--- a/plugin/cpp/CMakeLists.txt
+++ b/plugin/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ set_target_properties(transport-plugin PROPERTIES
 	VERSION ${TRANSPORT_VERSION} SOVERSION ${TRANSPORT_VERSION}
 )
 
-install(TARGETS transport-plugin LIBRARY DESTINATION ${LIB_INSTALL_DIR} ARCHIVE DESTINATION ${LIB_INSTALL_DIR} COMPONENT libraries)
+install(TARGETS transport-plugin LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
 #configure_file(transport.pc.in "${CMAKE_CURRENT_SOURCE_DIR}/transport.pc")
 #install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/transport.pc" DESTINATION lib/pkgconfig)

--- a/spectrum/src/CMakeLists.txt
+++ b/spectrum/src/CMakeLists.txt
@@ -23,31 +23,31 @@ if(NOT MSVC AND NOT APPLE)
 	set(CMAKE_EXE_LINKER_FLAGS "-Wl,-export-dynamic")
 endif()
 
-install(TARGETS spectrum2 RUNTIME DESTINATION bin)
+install(TARGETS spectrum2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES
 	sample2_gateway.cfg
 	RENAME spectrum.cfg.example
-	DESTINATION /etc/spectrum2/transports
+	DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/spectrum2/transports
 )
 
 install(FILES
 	sample2.cfg
 	RENAME spectrum_server_mode.cfg.example
-	DESTINATION /etc/spectrum2/transports
+	DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/spectrum2/transports
 )
 
 install(FILES
 	backend-logging.cfg
-	DESTINATION /etc/spectrum2
+	DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/spectrum2
 )
 
 install(FILES
 	logging.cfg
-	DESTINATION /etc/spectrum2
+	DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/spectrum2
 )
 
 install(FILES
 	manager-logging.cfg
-	DESTINATION /etc/spectrum2
+	DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/spectrum2
 )

--- a/spectrum_manager/src/CMakeLists.txt
+++ b/spectrum_manager/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE)
 	target_link_libraries(spectrum2_manager transport ${APPLE_FRAMEWORKS})
 endif()
 
-install(TARGETS spectrum2_manager RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_manager RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # if(NOT EXISTS "/etc/spectrum2/spectrum_manager.cfg")
 # install(FILES
@@ -28,12 +28,12 @@ install(TARGETS spectrum2_manager RUNTIME DESTINATION bin)
 # endif()
 
 install(CODE "
-if(NOT EXISTS \"$ENV{DESTDIR}/etc/spectrum2/spectrum_manager.cfg\")
-file(INSTALL DESTINATION \"/etc/spectrum2\" TYPE FILES \"${CMAKE_CURRENT_SOURCE_DIR}/spectrum_manager.cfg\")
+if(NOT EXISTS \"$ENV{DESTDIR}/${CMAKE_INSTALL_SYSCONFDIR}/spectrum2/spectrum_manager.cfg\")
+file(INSTALL DESTINATION \"${CMAKE_INSTALL_SYSCONFDIR}/spectrum2\" TYPE FILES \"${CMAKE_CURRENT_SOURCE_DIR}/spectrum_manager.cfg\")
 endif()
 ")
 
 install(DIRECTORY
 	html
-	DESTINATION /var/lib/spectrum2_manager
+	DESTINATION ${CMAKE_INSTALL_LOCALSTATEDIR}/lib/spectrum2_manager
 )


### PR DESCRIPTION
The installation target directories might be different on different distributions. For example, Debian using multiarch tuples paths for the libraries.

CMake provided a facility to set up certain variables to that the files will get installed into the correct directories. More details:
https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html