### PR TITLE
Install backends to /usr/libexec instead of /usr/bin (which is in $PATH)

### DIFF
--- a/backends/libcommuni/CMakeLists.txt
+++ b/backends/libcommuni/CMakeLists.txt
@@ -25,4 +25,4 @@ else()
 	endif()
 endif()
 
-install(TARGETS spectrum2_libcommuni_backend RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_libcommuni_backend RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/backends/libpurple/CMakeLists.txt
+++ b/backends/libpurple/CMakeLists.txt
@@ -4,4 +4,4 @@ add_executable(spectrum2_libpurple_backend ${SRC})
 
 target_link_libraries(spectrum2_libpurple_backend transport-plugin ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${EVENT_LIBRARIES})
 
-install(TARGETS spectrum2_libpurple_backend RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_libpurple_backend RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/backends/smstools3/CMakeLists.txt
+++ b/backends/smstools3/CMakeLists.txt
@@ -4,4 +4,4 @@ add_executable(spectrum2_smstools3_backend ${SRC})
 
 target_link_libraries(spectrum2_smstools3_backend transport pthread ${Boost_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES})
 
-install(TARGETS spectrum2_smstools3_backend RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_smstools3_backend RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/backends/swiften/CMakeLists.txt
+++ b/backends/swiften/CMakeLists.txt
@@ -8,4 +8,4 @@ else()
 	target_link_libraries(spectrum2_swiften_backend transport ${Boost_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES})
 endif()
 
-install(TARGETS spectrum2_swiften_backend RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_swiften_backend RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/backends/twitter/CMakeLists.txt
+++ b/backends/twitter/CMakeLists.txt
@@ -13,4 +13,4 @@ else()
 	message(FATAL_ERROR "curl not found")
 endif()
 
-install(TARGETS spectrum2_twitter_backend RUNTIME DESTINATION bin)
+install(TARGETS spectrum2_twitter_backend RUNTIME DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/spectrum/src/sample2.cfg
+++ b/spectrum/src/sample2.cfg
@@ -33,8 +33,8 @@ backend_host = 127.0.0.1
 users_per_backend=10
 
 # Full path to backend binary.
-backend=/usr/bin/spectrum2_libpurple_backend
-#backend=/usr/bin/spectrum2_libcommuni_backend
+#backend=/usr/libexec/spectrum2_libpurple_backend
+#backend=/usr/libexec/spectrum2_libcommuni_backend
 
 # Libpurple protocol-id for spectrum_libpurple_backend
 protocol=prpl-jabber

--- a/spectrum/src/sample2_gateway.cfg
+++ b/spectrum/src/sample2_gateway.cfg
@@ -27,8 +27,8 @@ backend_host = 127.0.0.1
 users_per_backend=10
 
 # Full path to backend binary.
-backend=/usr/bin/spectrum2_libpurple_backend
-#backend=/usr/bin/spectrum2_libcommuni_backend
+#backend=/usr/libexec/spectrum2_libpurple_backend
+#backend=/usr/libexec/spectrum2_libcommuni_backend
 
 # Libpurple protocol-id for spectrum_libpurple_backend
 protocol=prpl-jabber


### PR DESCRIPTION
(note: this requires #456 to be merged first. Splitted so that this topic can be properly discussed as this might be a breaking change:))

IIUIC the backends are not supposed to be executed directly by the user, but spawned using spectrum2_manager. In this case, the binaries should not be in $PATH, i.e outside of /usr/bin.

This patch installs the backends to /usr/libexec [1], as this matches the FSH intention for this directory.

[1] https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html