### PR TITLE
Reject empty password and "test" for the webinterface.

### DIFF
--- a/spectrum_manager/src/server.cpp
+++ b/spectrum_manager/src/server.cpp
@@ -71,8 +71,8 @@ Server::Server(ManagerConfig *config, const std::string &config_file) {
 	mg_mgr_init(&m_mgr, this);
 
 	if(m_password == "" || m_password == "test") {
-        std::cerr << "Rejecting empty or default admin password." << std::endl;
-        exit(1);
+		std::cerr << "Rejecting empty or default admin password." << std::endl;
+		exit(1);
 	}
 
 	struct mg_bind_opts opts;

--- a/spectrum_manager/src/server.cpp
+++ b/spectrum_manager/src/server.cpp
@@ -70,6 +70,11 @@ Server::Server(ManagerConfig *config, const std::string &config_file) {
 
 	mg_mgr_init(&m_mgr, this);
 
+	if(m_password == "" || m_password == "test") {
+        std::cerr << "Rejecting empty or default admin password." << std::endl;
+        exit(1);
+	}
+
 	struct mg_bind_opts opts;
 	memset(&opts, 0, sizeof(opts));
 	const char *error_string;

--- a/spectrum_manager/src/spectrum_manager.cfg
+++ b/spectrum_manager/src/spectrum_manager.cfg
@@ -2,8 +2,11 @@
 config_directory=/etc/spectrum2/transports/
 
 # Username and password of admin for Web interface
+# Note: The server will reject:
+# - an empty password,
+# - "test" as password (used in previous versions as default password.)
 admin_username=admin
-admin_password=test
+admin_password=
 
 # Bind web interface to this IP only. If empty or undefined it will listen on all interfaces.
 # defaults to localhost. Set to empty string to listen on all interfaces.


### PR DESCRIPTION
Well, this is aimed to protect the unaware or the dontcare for inadvertently opening up their spectrum2 webinterface to the world, creating all sorts of security issues on the way…

(I'm using this patch for the Debian package for a hardened default setup; when the user installs the webinterface package, this will automatically also start it, so this is needed for an secure user experience…)