### PR TITLE
Better NickServ identify command ?

### DIFF
--- a/backends/libcommuni/ircnetworkplugin.cpp
+++ b/backends/libcommuni/ircnetworkplugin.cpp
@@ -50,7 +50,7 @@ IRCNetworkPlugin::IRCNetworkPlugin(Config *config, Swift::QtEventLoop *loop, con
 		m_identify = CONFIG_STRING(m_config, "service.irc_identify");
 	}
 	else {
-		m_identify = "NickServ identify $name $password";
+		m_identify = "NickServ identify $password";
 	}
 }
 


### PR DESCRIPTION
Unfortunatly every network is doing the NickServ Identify command a bit differently, but it seeems that "NickServ IDENTIFY password" is universally accepted.

OFTC e.g it is NickServ IDENTIFY password [nick] [1] libera.chat it is NickServ IDENTIFY [nick] password. [2] same for dal.net [3]

(I guess those three are the most important networks with NickServ)

I've tested the patch on otfc, I can still connect and authenticate to that network.

[1] on OFTC:
```
17:24 <tobi> help identify
17:24 -NickServ(services@services.oftc.net)- *** IDENTIFY Help *** 17:24 -NickServ(services@services.oftc.net)- Usage: IDENTIFY password [nick] 17:24 -NickServ(services@services.oftc.net)-
17:24 -NickServ(services@services.oftc.net)- Identify that you are the owner of the nick you are currently using. 17:24 -NickServ(services@services.oftc.net)- If you specify a nickname to identify against, your IRC nick will 17:24 -NickServ(services@services.oftc.net)- automatically be changed to the one you identify for. 17:24 -NickServ(services@services.oftc.net)-
17:24 -NickServ(services@services.oftc.net)- See also: REGISTER 17:24 -NickServ(services@services.oftc.net)- *** End of IDENTIFY Help ***
```

[2] on libera.chat, the help says:
```
17:23 <tobi> help identify
17:23 -NickServ(NickServ@services.libera.chat)- ***** NickServ Help ***** 17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- Help for IDENTIFY: 17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- IDENTIFY identifies you with services so that you 17:23 -NickServ(NickServ@services.libera.chat)- can perform general maintenance and commands that 17:23 -NickServ(NickServ@services.libera.chat)- require you to be logged in. 17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- Syntax: IDENTIFY <nick> <password>
17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- You can also omit <nick> to identify to the nick 17:23 -NickServ(NickServ@services.libera.chat)- you are currently using. 17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- Syntax: IDENTIFY <password>
17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- Example:
17:23 -NickServ(NickServ@services.libera.chat)-     /msg NickServ IDENTIFY jilles foo
17:23 -NickServ(NickServ@services.libera.chat)-
17:23 -NickServ(NickServ@services.libera.chat)- ***** End of Help *****

```
[3] Dalnet help identify:
```
17:55 -NickServ(service@dal.net)- ***** NickServ Help ***** 17:55 -NickServ(service@dal.net)- Command - IDENTIFY
17:55 -NickServ(service@dal.net)- Usage   - IDENTIFY <password>
17:55 -NickServ(service@dal.net)-           IDENTIFY <nick> <password>
17:55 -NickServ(service@dal.net)-
17:55 -NickServ(service@dal.net)- This tells NickServ that you are the owner of a certain nickname.
17:55 -NickServ(service@dal.net)- After you have identified, you have full access to the nickname.
17:55 -NickServ(service@dal.net)-
17:55 -NickServ(service@dal.net)- If a nick parameter isn't given, your current nick will be used.
17:55 -NickServ(service@dal.net)-
17:55 -NickServ(service@dal.net)- Example:
17:55 -NickServ(service@dal.net)- /msg NickServ@services.dal.net IDENTIFY HiNellieBell
17:55 -NickServ(service@dal.net)- /msg NickServ@services.dal.net IDENTIFY Kobi_S HiNellieBell
```

Note: "name" as third parameter is actually an extension, not all irc servers accept that. oftc and libera.chat do, although…