### PR TITLE
Switch from CXX11 to CXX14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy(SET CMP0037 OLD)
 
 project(libtransport)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 if(WIN32)
 	set(CMAKE_CXX_STANDARD 17)
 endif(WIN32)


### PR DESCRIPTION
Switch from CXX11 to CXX14, so compilation will not fail with GCC-14.

See https://bugs.gentoo.org/921575 for full build log.