### PR TITLE
CMake: set c++ standard using `target_compile_features`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         set CMAKE_PREFIX_PATH=%cd%\deps32
         set PATH=%PATH%;%cd%\deps32\bin;%cd%\deps32\tools\bin
-        cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TESTS=ON -DENABLE_IRC=OFF -DENABLE_FROTZ=OFF -DENABLE_PURPLE=OFF -DENABLE_MYSQL=OFF -DENABLE_PQXX=OFF -DCMAKE_INSTALL_PREFIX=dist .
+        cmake -G "Visual Studio 17 2022" -A Win32 -DCMAKE_UNITY_BUILD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TESTS=ON -DENABLE_IRC=OFF -DENABLE_FROTZ=OFF -DENABLE_PURPLE=OFF -DENABLE_MYSQL=OFF -DENABLE_PQXX=OFF -DCMAKE_INSTALL_PREFIX=dist -DCMAKE_CXX_STANDARD=17 .
       shell: cmd
     - name: Build solution
       run:  msbuild /t:Build INSTALL.vcxproj /p:Configuration=RelWithDebInfo /p:Platform=Win32 /m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,6 @@ cmake_policy(SET CMP0037 OLD)
 
 project(libtransport)
 
-set(CMAKE_CXX_STANDARD 11)
-if(WIN32)
-	set(CMAKE_CXX_STANDARD 17)
-endif(WIN32)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 include(GNUInstallDirs)
 
 include(CPack)

--- a/backends/frotz/CMakeLists.txt
+++ b/backends/frotz/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(dfrotz)
 file(GLOB SRC *.c *.cpp)
 
 add_executable(spectrum2_frotz_backend ${SRC})
-
+target_compile_features(spectrum2_frotz_backend PUBLIC cxx_std_11)
 
 target_link_libraries(spectrum2_frotz_backend transport pthread ${Boost_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES})
 

--- a/backends/libcommuni/CMakeLists.txt
+++ b/backends/libcommuni/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 add_definitions(-DQT_NO_KEYWORDS)
 add_executable(spectrum2_libcommuni_backend ${SRC})
+target_compile_features(spectrum2_libcommuni_backend PUBLIC cxx_std_11)
 
 if(NOT WIN32)
 	if(ENABLE_QT4)

--- a/backends/libpurple/CMakeLists.txt
+++ b/backends/libpurple/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB SRC *.cpp)
 
 add_executable(spectrum2_libpurple_backend ${SRC})
+target_compile_features(spectrum2_libpurple_backend PUBLIC cxx_std_11)
 
 target_link_libraries(spectrum2_libpurple_backend transport-plugin ${PURPLE_LIBRARY} ${GLIB2_LIBRARIES} ${EVENT_LIBRARIES})
 

--- a/backends/smstools3/CMakeLists.txt
+++ b/backends/smstools3/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB SRC *.c *.cpp)
 
 add_executable(spectrum2_smstools3_backend ${SRC})
+target_compile_features(spectrum2_smstools3_backend PUBLIC cxx_std_11)
 
 target_link_libraries(spectrum2_smstools3_backend transport pthread ${Boost_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES})
 

--- a/backends/swiften/CMakeLists.txt
+++ b/backends/swiften/CMakeLists.txt
@@ -1,6 +1,8 @@
 file(GLOB SRC *.cpp)
 
 add_executable(spectrum2_swiften_backend ${SRC})
+target_compile_features(spectrum2_swiften_backend PUBLIC cxx_std_11)
+
 
 if(NOT WIN32)
 	target_link_libraries(spectrum2_swiften_backend transport pthread ${Boost_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES})

--- a/backends/template/CMakeLists.txt
+++ b/backends/template/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB SRC *.c *.cpp)
 
 add_executable(spectrum2_template_backend ${SRC})
+target_compile_features(spectrum2_template_backend PUBLIC cxx_std_11)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 	if(NOT WIN32)

--- a/libtransport/CMakeLists.txt
+++ b/libtransport/CMakeLists.txt
@@ -45,6 +45,7 @@ endif(PROTOBUF_FOUND)
 find_package(CURL)
 
 target_link_libraries(transport transport-plugin ${CURL_LIBRARIES} ${SQLITE3_LIBRARIES} ${MYSQL_LIBRARIES} ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES} ${POPT_LIBRARY} ${PROTOBUF_LIBRARY} JsonCpp::JsonCpp)
+target_compile_features(transport PUBLIC cxx_std_11)
 
 if(WIN32)
 	target_link_libraries(transport psapi.lib bcrypt.lib)

--- a/plugin/cpp/CMakeLists.txt
+++ b/plugin/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 add_dependencies(transport-plugin pb)
 set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/../../include/transport/protocol.pb.cc PROPERTIES GENERATED 1)
+target_compile_features(transport-plugin PUBLIC cxx_std_11)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 	if(NOT WIN32)

--- a/spectrum/src/CMakeLists.txt
+++ b/spectrum/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_dependencies(spectrum2 spectrum2_libpurple_backend)
 endif()
 
 target_link_libraries(spectrum2 transport spectrum2-xmpp-frontend spectrum2-slack-frontend ${SWIFTEN_LIBRARY} ${LOG4CXX_LIBRARIES} ${PROTOBUF_LIBRARY})
+target_compile_features(spectrum2 PUBLIC cxx_std_11)
 
 if(NOT MSVC AND NOT APPLE)
 	# export all symbols (used for loading frontends)

--- a/spectrum/src/frontends/slack/CMakeLists.txt
+++ b/spectrum/src/frontends/slack/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 add_dependencies(spectrum2-slack-frontend transport)
+target_compile_features(spectrum2-slack-frontend PUBLIC cxx_std_11)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 	if(NOT WIN32)

--- a/spectrum/src/frontends/xmpp/CMakeLists.txt
+++ b/spectrum/src/frontends/xmpp/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
 endif()
 
 add_dependencies(spectrum2-xmpp-frontend transport)
+target_compile_features(spectrum2-xmpp-frontend PUBLIC cxx_std_11)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
 	if(NOT WIN32)

--- a/spectrum_manager/src/CMakeLists.txt
+++ b/spectrum_manager/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/../../include/transport/
 
 target_include_directories(spectrum2_manager PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(spectrum2_manager transport ${SWIFTEN_LIBRARY} ${PROTOBUF_LIBRARIES})
+target_compile_features(spectrum2_manager PUBLIC cxx_std_11)
 
 if (ENABLE_WEBUI)
 	add_definitions(-DENABLE_WEBUI)

--- a/tests/libtransport/CMakeLists.txt
+++ b/tests/libtransport/CMakeLists.txt
@@ -25,6 +25,7 @@ if(CPPUNIT_FOUND)
 	file(GLOB SRC_TEST_FRONTEND_SLACK ../../spectrum/src/frontends/slack/*.cpp)
 
 	add_executable(libtransport_test ${SRC_TEST} ${SRC_TEST_FRONTEND_XMPP} ${SRC_TEST_FRONTEND_SLACK})
+	target_compile_features(libtransport_test PUBLIC cxx_std_11)
 	set_target_properties(libtransport_test PROPERTIES COMPILE_DEFINITIONS LIBTRANSPORT_TEST=1)
 	
 


### PR DESCRIPTION
* This will allow to override with -DCMAKE_CXX_STANDARD=20

Fixes [#496](https://github.com/SpectrumIM/spectrum2/issues/496)