### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
 jobs:
   linux-glibc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SpectrumIM/spectrum2/security/code-scanning/29](https://github.com/SpectrumIM/spectrum2/security/code-scanning/29)

To fix this problem, you should explicitly specify the `permissions` key at the root of the workflow YAML file, before the `jobs` section. This will constrain the GITHUB_TOKEN to only have the privileges needed for the workflow. Since the jobs perform code checkout, build, and test, but do not appear to require write permissions, the minimal required permission is `contents: read`. This permissions block should be added at the top level of `.github/workflows/main.yml`, ideally immediately after the `name:` and `on:` sections, before the `jobs:` key. No additional imports or changes are necessary; simply add:

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
