### PR TITLE
cmake: fix -Wl,--export-dynamic typo

### DIFF
--- a/spectrum/src/CMakeLists.txt
+++ b/spectrum/src/CMakeLists.txt
@@ -21,7 +21,7 @@ target_compile_features(spectrum2 PUBLIC cxx_std_11)
 
 if(NOT MSVC AND NOT APPLE)
 	# export all symbols (used for loading frontends)
-	set(CMAKE_EXE_LINKER_FLAGS "-Wl,-export-dynamic")
+	set(CMAKE_EXE_LINKER_FLAGS "-Wl,--export-dynamic")
 endif()
 
 install(TARGETS spectrum2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
'-Wl,-export-dynamic' will be interpreted as '-Wl,-e xport-dynamic'.