### PR TITLE
Fix build when ENABLE_SLACK_FRONTEND=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,10 @@ endif()
 
 add_definitions(-DSUPPORT_LEGACY_CAPS)
 
+if(ENABLE_SLACK_FRONTEND)
+	add_definitions(-DENABLE_SLACK_FRONTEND)
+endif()
+
 if(ENABLE_IRC)
 	find_package(Communi)
 	find_package(Qt5 COMPONENTS Core Network)

--- a/spectrum/src/main.cpp
+++ b/spectrum/src/main.cpp
@@ -14,7 +14,9 @@
 #include "transport/Logging.h"
 #include "transport/Frontend.h"
 #include "frontends/xmpp/XMPPFrontendPlugin.h"
+#ifdef ENABLE_SLACK_FRONTEND
 #include "frontends/slack/SlackFrontendPlugin.h"
+#endif
 #include "Swiften/EventLoop/SimpleEventLoop.h"
 #include "Swiften/Network/BoostNetworkFactories.h"
 #include <boost/thread.hpp>


### PR DESCRIPTION
PR #541 added the ENABLE_SLACK_FRONTEND CMake option but missed two things:

1. **CMakeLists.txt**: no `add_definitions(-DENABLE_SLACK_FRONTEND)` when option is ON, so the `#ifdef` guard in main.cpp never triggered
2. **main.cpp**: `SlackFrontendPlugin.h` included unconditionally — the `BOOST_DLL_ALIAS` macro generated an undefined reference to `get_slack_frontend_plugin()` at link time when Slack frontend was not built

Fixes the arm64 publish build that failed on master after #541 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)