### PR TITLE
Fix frotz boost filesystem v4 compatibility (boost-1.85)

### DIFF
--- a/backends/frotz/main.cpp
+++ b/backends/frotz/main.cpp
@@ -219,7 +219,7 @@ class FrotzNetworkPlugin : public BoostNetworkPlugin {
 			path p(".");
 			directory_iterator end_itr;
 			for (directory_iterator itr(p); itr != end_itr; ++itr) {
-				if (extension(itr->path()) == ".z5") {
+				if (itr->path().extension().string() == ".z5") {
 #if BOOST_FILESYSTEM_VERSION == 3
 					games.push_back(itr->path().filename().string());
 #else


### PR DESCRIPTION
the frotz backend was missed in my original filesystem v4 patch for gentoo, that was later sent as a PR #497