### PR TITLE
boost::asio::ip:address::from_string compat fix

### DIFF
--- a/plugin/cpp/BoostNetworkPlugin.cpp
+++ b/plugin/cpp/BoostNetworkPlugin.cpp
@@ -22,6 +22,7 @@
 #include "transport/Logging.h"
 
 #include <boost/thread.hpp>
+#include <boost/version.hpp>
 
 DEFINE_LOGGER(pluginLogger, "Backend");
 
@@ -31,7 +32,11 @@ BoostNetworkPlugin::BoostNetworkPlugin(Config *config, const std::string &host,
     : NetworkPlugin(), io_context() {
   this->config = config;
   LOG4CXX_INFO(pluginLogger, "Starting the plugin.");
+#if BOOST_VERSION >= 106600
+  boost::asio::ip::tcp::endpoint ep(boost::asio::ip::make_address(host), port);
+#else
   boost::asio::ip::tcp::endpoint ep(boost::asio::ip::address::from_string(host), port);
+#endif
   socket_ = std::make_shared<boost::asio::ip::tcp::socket>(io_context);
   socket_->async_connect(ep, [this, host](boost::system::error_code ec) {
     if (!ec) {


### PR DESCRIPTION
boost::asio::ip::address::from_string was deprecated in boost-1.66 and removed in boost-1.87