### PR TITLE
boost::asio::ip:address and boost::asio::<timer> compat fix

### DIFF
--- a/backends/smstools3/main.cpp
+++ b/backends/smstools3/main.cpp
@@ -95,7 +95,7 @@ class SMSNetworkPlugin : public BoostNetworkPlugin {
 			for (directory_iterator itr(p); itr != end_itr; ++itr) {
 
 				try {
-					if (is_regular(itr->path())) {
+					if (is_regular_file(itr->path())) {
 						handleSMS(itr->path().string());
 						remove(itr->path());
 					}

--- a/backends/smstools3/main.cpp
+++ b/backends/smstools3/main.cpp
@@ -35,14 +35,14 @@ SMSNetworkPlugin * np = NULL;
 
 class SMSNetworkPlugin : public BoostNetworkPlugin {
 	public:
-		std::shared_ptr<boost::asio::deadline_timer> m_timer;
+		std::shared_ptr<boost::asio::system_timer> m_timer;
 		// Maps phone number -> XMPP user JID for SMS routing
 		std::map<std::string, std::string> m_numberToUser;
 
 		SMSNetworkPlugin(Config *config, const std::string &host, int port)
 			: BoostNetworkPlugin(config, host, port) {
 
-			m_timer = std::make_shared<boost::asio::deadline_timer>(io_context, boost::posix_time::seconds(5));
+			m_timer = std::make_shared<boost::asio::system_timer>(io_context, std::chrono::seconds(5));
 			m_timer->async_wait(boost::bind(&SMSNetworkPlugin::handleSMSDir, this));
 		}
 
@@ -105,7 +105,7 @@ class SMSNetworkPlugin : public BoostNetworkPlugin {
 				}
 			}
 
-			m_timer->expires_from_now(boost::posix_time::seconds(5));
+			m_timer->expires_after(std::chrono::seconds(5));
 			m_timer->async_wait(boost::bind(&SMSNetworkPlugin::handleSMSDir, this));
 		}
 

--- a/plugin/cpp/BoostNetworkPlugin.cpp
+++ b/plugin/cpp/BoostNetworkPlugin.cpp
@@ -31,7 +31,7 @@ BoostNetworkPlugin::BoostNetworkPlugin(Config *config, const std::string &host,
     : NetworkPlugin(), io_context() {
   this->config = config;
   LOG4CXX_INFO(pluginLogger, "Starting the plugin.");
-  boost::asio::ip::tcp::endpoint ep(boost::asio::ip::address::from_string(host), port);
+  boost::asio::ip::tcp::endpoint ep(boost::asio::ip::make_address(host), port);
   socket_ = std::make_shared<boost::asio::ip::tcp::socket>(io_context);
   socket_->async_connect(ep, [this, host](boost::system::error_code ec) {
     if (!ec) {


### PR DESCRIPTION
fixes compatibility with newer boost versions for
boost::asio::ip:address
boost::asio::deadline_timer / boost::asio::system_timer

fixes boost filesystem api v4 for smstools backend